### PR TITLE
Association name override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+* Option to override association name
 
 ## [0.0.1] - 2022-4-12
 * Inital implementation

--- a/lib/absinthe_quarry/extract.ex
+++ b/lib/absinthe_quarry/extract.ex
@@ -46,10 +46,14 @@ defmodule AbsintheQuarry.Extract do
   defp extract_loads(fields) do
     fields
     |> Enum.filter(&should_load?/1)
-    |> Enum.map(fn field ->
-      %{schema_node: %{identifier: field_name}} = field
-      {field_name, extract_child(field)}
-    end)
+    |> Enum.map(&{extract_assoc_name(&1), extract_child(&1)})
+  end
+
+  defp extract_assoc_name(%{schema_node: node}) do
+    case Absinthe.Type.meta(node, :quarry) do
+      conf when is_list(conf) -> Keyword.get(conf, :assoc, node.identifier)
+      _ -> node.identifier
+    end
   end
 
   defp extract_child(%{argument_data: args, selections: selections}) when map_size(args) == 0 do

--- a/test/absinthe_quarry/extract_test.exs
+++ b/test/absinthe_quarry/extract_test.exs
@@ -30,6 +30,7 @@ defmodule AbsintheQuarry.ExtractTest do
       field :field1, :string
 
       field :child, :child, meta: [quarry: true]
+      field :child2, :child, meta: [quarry: [assoc: :child]]
 
       field :children, list_of(:child), meta: [quarry: true] do
         arg :filter, :child_filter
@@ -114,5 +115,11 @@ defmodule AbsintheQuarry.ExtractTest do
     query = "query { parents { children(filter: { field1: \"test\"}) { field1 } } }"
     assert {:ok, %{data: _}} = Absinthe.run(query, Schema)
     assert_receive load: [children: [filter: %{field1: "test"}]]
+  end
+
+  test "can alias a field to a different association" do
+    query = "query { parents { child2 { field1 } } }"
+    assert {:ok, %{data: _}} = Absinthe.run(query, Schema)
+    assert_receive load: [child: []]
   end
 end


### PR DESCRIPTION
Resolves #1 
Allow setting field name override
```elixir
field :child2, :child, meta: [quarry: [assoc: :child]]
```